### PR TITLE
Adding a build job dependency to publish job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,6 +77,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/master' && github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/')
+    needs: build
     strategy:
       matrix:
        include:


### PR DESCRIPTION
Adding a build job dependency to publish job

Signed-off-by: David Cassany <dcassany@suse.com>