### PR TITLE
Add README file and simplify Makefile

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+cos-build() {
+ if [[ -z "$(docker images | grep cos-builder)" ]]; then
+    docker build -t cos-builder .
+ fi
+
+  docker run \
+ -ti --privileged=true \
+ --device=/dev/loop-control:/dev/loop-control \
+ --device=/dev/loop0:/dev/loop0 \
+ --cap-add SYS_ADMIN \
+ --rm \
+ -v /var/run/docker.sock:/var/run/docker.sock \
+ -v $PWD:/cOS \
+ cos-builder
+}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "packages/cOS"]
-	path = packages/cOS
-	url = https://github.com/rancher-sandbox/cOS-toolkit

--- a/.luet.yaml
+++ b/.luet.yaml
@@ -1,0 +1,6 @@
+repositories:
+  - name: cOS
+    enable: true
+    urls:
+      - raccos/releases-opensuse
+    type: docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM opensuse/leap
+
+RUN zypper in -y docker curl squashfs xorriso dosfstools make
+
+RUN curl https://get.mocaccino.org/luet/get_luet_root.sh |  sh
+ENV LUET_NOLOCK=true
+
+RUN luet install -y repository/mocaccino-extra-stable
+RUN luet install -y utils/jq utils/yq system/luet-devkit container/img
+
+RUN zypper in -y which
+
+COPY . /cOS
+WORKDIR /cOS
+
+ENTRYPOINT ["/usr/bin/make"]
+CMD ["build", "local-iso"]
+

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,12 @@ CLEAN?=false
 export TREE?=$(ROOT_DIR)/packages
 
 BUILD_ARGS?=--pull --no-spinner --only-target-package --live-output
-FLAVOR?=opensuse
 VALIDATE_OPTIONS?=-s
 REPO_CACHE?=raccos/sampleos
-PULL_REPOS?=raccos/$(FLAVOR)
+PULL_REPOS?=raccos/opensuse
 FINAL_REPO?=raccos/releases-sampleos
 
-PACKAGES?=$(shell yq r -j $(ISO_SPEC) 'packages.[*]' | jq -r '.[]' | sort -u)
+PACKAGES?=system/sampleOS
 HAS_LUET := $(shell command -v luet 2> /dev/null)
 PUBLISH_ARGS?=
 ISO?=$(ROOT_DIR)/$(shell ls *.iso)
@@ -45,26 +44,25 @@ clean:
 .PHONY: build
 build:
 	$(LUET) build $(BUILD_ARGS) \
-	--values $(ROOT_DIR)/packages/cOS/values/$(FLAVOR).yaml \
-	--tree=$(TREE) $(PACKAGES) \
-	--destination $(ROOT_DIR)/build
+	--destination $(ROOT_DIR)/build \
+	--from-repositories $(PACKAGES)
 
 create-repo:
-	$(LUET) create-repo --tree "$(TREE)" \
-    --output $(ROOT_DIR)/build \
-    --packages $(ROOT_DIR)/build \
-    --name "sampleOS" 
+	$(LUET) create-repo \
+	--output $(ROOT_DIR)/build \
+	--name "sampleOS" \
+	--from-repositories 
 
 publish-repo:
-	$(LUET) create-repo $(PUBLISH_ARGS) --tree "$(TREE)" \
-    --output $(FINAL_REPO) \
-    --packages $(ROOT_DIR)/build \
-    --name "sampleOS" \
-    --push-images \
-    --type docker
+	$(LUET) create-repo $(PUBLISH_ARGS) \
+	--output $(FINAL_REPO) \
+	--name "sampleOS" \
+	--from-repositories \
+	--push-images \
+	--type docker
 
 validate:
-	$(LUET) tree validate --tree $(TREE) $(VALIDATE_OPTIONS)
+	$(LUET) tree validate $(VALIDATE_OPTIONS)
 
 # ISO
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ qemu-img create -f raw test.img 20G
 $ qemu-kvm -m 2048 -cdrom sampleOS-0.20210415.iso -hda test.img
 ```
 
-After loging into the VM you can check SampleService by typing:
+Default root password is set to `sampleos` on in [04_accounting.yaml](https://github.com/rancher-sandbox/cos-toolkit-sample-repo/blob/master/packages/sampleOS/04_accounting.yaml), then, after loging into the VM, you can check SampleService by typing:
 
 ```bash
 # Service status
@@ -35,6 +35,24 @@ systemctl status sampleservice
 
 # Check is up and running properly
 curl -L http://localhost:8090/fortuneteller
+```
+
+## Build SampleOS With docker
+
+cOS has a docker image which can be used to build cOS locally in order to generate the cOS packages and the cOS iso from your checkout.
+
+From your git folder:
+
+```bash
+$> docker build -t cos-builder .
+$> docker run --privileged=true --rm -v /var/run/docker.sock:/var/run/docker.sock -v $PWD:/cOS cos-builder
+```
+
+or use the `.envrc` file:
+
+```bash
+$> source .envrc
+$> cos-build
 ```
 
 ## Build SampleOS Locally
@@ -66,22 +84,39 @@ $ sudo make local-iso
 ### Manual build without Makefile targets
 
 The sampleOS relies on [**luet**](https://luet-lab.github.io/docs/) for the build, in fact this is the
-core of the toolchain. Once luet is installed on the system consider running
-the following commands to build SampleOS.
+core of the toolchain. Consider running the following commands to build SampleOS.
 
+Install OS dependencies for ISO and filesystems management:
+
+```bash
+# Install packages for openSUSE
+zypper in squashfs xorriso dosfstools
+```
+
+Install luet and its extensions:
+
+```bash
+# Installing Luet
+$ curl https://get.mocaccino.org/luet/get_luet_root.sh |  sh
+
+# Install the luet extensions repository configuration
+$ sudo luet install -y repository/mocaccino-extra-stable
+
+# Install luet extensions and utilities require for ISO creation
+$ sudo luet install -y utils/jq utils/yq system/luet-devkit
+```
 
 Build the SampleOS root tree:
 
 ```bash
 $ sudo luet build --only-target-package --pull --image-repository raccos/sampleos \
-     --pull-repository raccos/opensuse --values packages/cOS/values/opensuse.yaml \
-     --tree packages --all --destination build
+     --pull-repository raccos/opensuse --destination build --from-repositories system/sampleOS
 ```
 
 Create the local repository for the build packages:
 
 ```bash
-$ luet create-repo --tree packages --output build --packages build --name sampleOS
+$ luet create-repo --output build --name sampleOS --from-repositories
 ```
 
 Generate the ISO

--- a/README.md
+++ b/README.md
@@ -1,0 +1,91 @@
+# SampleOS
+
+SampleOS is a dummy example of a derivate system based on containerOS (**cOS**).
+The purpose of this repository is moslty to showcase and demonstrate how to
+extend and customize containerOS using its own toolkit.
+
+cOS is built from containers, and completely hosted on image registries. The
+build process results in a single container image used to deliver regular
+upgrades in OTA approach. Refer to [**cOS project**](https://github.com/rancher-sandbox/cOS-toolkit) for further details
+regarding the toolkit or the base cOS system.
+
+This SampleOS only includes a dummy http service on top of the cOS base that
+listens to `http://<IP>:8090/fortuneteller` which is enabled through a
+cloud-init configuration ([10_sampleOSService.yaml](https://github.com/rancher-sandbox/cos-toolkit-sample-repo/blob/master/packages/sampleOSService/10_sampleOSService.yaml)) applied at
+boot time the over the ephemeral `/etc`.
+
+## Quick start
+
+Download the ISO (see actions [artifacts](https://github.com/rancher-sandbox/cos-toolkit-sample-repo/actions)) and boot it with the hipervisor of
+your choice. The ISO can be simply boot using KVM with the following commands:
+
+```bash
+# create a virtual disk of 20G
+$ qemu-img create -f raw test.img 20G
+
+# Run a VM with the ISO
+$ qemu-kvm -m 2048 -cdrom sampleOS-0.20210415.iso -hda test.img
+```
+
+After loging into the VM you can check SampleService by typing:
+
+```bash
+# Service status
+systemctl status sampleservice
+
+# Check is up and running properly
+curl -L http://localhost:8090/fortuneteller
+```
+
+## Build SampleOS Locally
+
+SampleOS can be build locally by using the following make targets.
+
+Install build dependencies:
+
+```bash
+# Install toolchain dependencies (luet, luet-extensions and yq)
+$ sudo make deps
+```
+
+Build the actual sampleOS root tree:
+
+```bash
+# Builds all the packages of the repository
+$ sudo make build
+```
+
+Create an ISO with the built root tree from SampleOS:
+
+```bash
+# Creates a local repo and builds an ISO using the local repository
+# on top of the raccos/realeases-cos docker repository
+$ sudo make local-iso
+```
+
+### Manual build without Makefile targets
+
+The sampleOS relies on [**luet**](https://luet-lab.github.io/docs/) for the build, in fact this is the
+core of the toolchain. Once luet is installed on the system consider running
+the following commands to build SampleOS.
+
+
+Build the SampleOS root tree:
+
+```bash
+$ sudo luet build --only-target-package --pull --image-repository raccos/sampleos \
+     --pull-repository raccos/opensuse --values packages/cOS/values/opensuse.yaml \
+     --tree packages --all --destination build
+```
+
+Create the local repository for the build packages:
+
+```bash
+$ luet create-repo --tree packages --output build --packages build --name sampleOS
+```
+
+Generate the ISO
+
+```bash
+$ sudo luet geniso-isospec iso/sampleOS.yaml
+```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SampleOS
 
-SampleOS is a dummy example of a derivate system based on containerOS (**cOS**).
+SampleOS is a dummy example of a derivate system built with containerOS-toolkit (**cOS-toolkit**).
 The purpose of this repository is moslty to showcase and demonstrate how to
 extend and customize containerOS using its own toolkit.
 

--- a/build/conf.yaml
+++ b/build/conf.yaml
@@ -1,0 +1,11 @@
+repositories:
+  - name: cOS
+    enable: true
+    urls:
+      - raccos/releases-opensuse
+    type: docker
+  - name: sampleOS
+    enable: true
+    urls:
+      - build
+    type: disk


### PR DESCRIPTION
This commit provides a simple README file simplifies the Makefile since
the purpose of this project is no providing tones of options but
providing simple skeleton for anyone to get started tweaking.