### PR TITLE
Drop validate from workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,10 +52,6 @@ jobs:
       run: |
         sudo -E make deps
 
-    - name: Validate 🌳
-      run: |
-        make validate
-
     - name: Build packages 🔧
       run: |
         sudo -E make build


### PR DESCRIPTION
We can't run it as we do in cos-toolkit as we don't have a cOS checkout by default anymore