### PR TITLE
Adapt to base off from 0.5.x

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,6 +56,7 @@ jobs:
       run: |
         sudo -E make build
         ls -liah $PWD/build
+        sudo chmod -R 777 build
 
     - name: Create repo
       run: |

--- a/.luet.yaml
+++ b/.luet.yaml
@@ -2,5 +2,5 @@ repositories:
   - name: cOS
     enable: true
     urls:
-      - raccos/releases-opensuse
+      - quay.io/costoolkit/releases-opensuse
     type: docker

--- a/iso.yaml
+++ b/iso.yaml
@@ -22,5 +22,5 @@ luet:
   - name: cOS
     enable: true
     urls:
-      - raccos/releases-opensuse
+      - quay.io/costoolkit/releases-opensuse
     type: docker

--- a/packages/sampleOS/04_accounting.yaml
+++ b/packages/sampleOS/04_accounting.yaml
@@ -10,8 +10,7 @@ stages:
    initramfs:
      - name: "Setup users"
        ensure_entities:
-       - path: /etc/shadow
-         entity: |
+       - entity: |
             kind: "shadow"
             username: "root"
-            password: "$1$zbqaUEOw$iHflRXL1l1Hs9W1DMJWOO0"
+            password: "sampleos"

--- a/packages/sampleOS/build.yaml
+++ b/packages/sampleOS/build.yaml
@@ -1,88 +1,38 @@
-requires:
+# join the resulting package in a new image (https://luet-lab.github.io/docs/docs/concepts/packages/specfile/#join) 
+# 
+# See also https://github.com/rancher-sandbox/cos-toolkit-sample-repo/commit/1e9e33a7feb600ecef5948d137659f95e8e31b0b
+# for an equivalent using a different strategy
+join:
 - category: "system"
   name: "cos"
   version: ">=0"
 - category: "app"
   name: "sampleOSService"
   version: ">=0"
+- category: "selinux"
+  name: "policy"
+  version: ">=0"
+
+# Run the steps in the resulting container
 steps:
 - sed -i 's/:VERSION:/{{.Values.version}}/g' setup.yaml
 - sed -i 's/:PRETTY_NAME:/{{.Values.brand_name}} v{{.Values.version}}/g' setup.yaml
 - cp -fv 02_upgrades.yaml /system/oem/02_upgrades.yaml
 - cp -fv 03_branding.yaml /system/oem/03_branding.yaml
 - cp -fv 04_accounting.yaml /system/oem/04_accounting.yaml
+- useradd --system dummyuser
 - yip setup.yaml
 
+# This tells luet to create a package from the resulting container content.
+# The image will be squashed and unpacked
+# See also: https://luet-lab.github.io/docs/docs/concepts/packages/specfile/#unpack
 unpack: true
+
+# A regexp list of patterns
+# to exclude from the resulting image
+# See also: https://luet-lab.github.io/docs/docs/concepts/packages/specfile/#excludes
 excludes:
 - ^/var/cache/luet
 - ^/luetbuild
-- ^/srv/.*
 - ^/root/.bash_history
 - ^/run/reboot-needed
-
-# Zypper
-- ^/var/lib/zypp
-- ^/var/cache/zypp
-- ^/usr/share/zypper
-- ^/usr/share/zypp
-- ^/usr/share/zsh
-- ^/usr/share/licenses/zypper
-- ^/usr/bin/zypp-.*
-- ^/usr/bin/zypper
-- ^/usr/lib/zypp$
-- ^/usr/lib/zypper
-- ^/usr/lib/rpm
-- ^/usr/bin/yzpper
-- ^/usr/sbin/zypp-.*
-- ^/usr/bin/zypp-.*
-- ^/usr/bin/susetags2solv
-- ^/run/zypp.*
-- ^/etc/zypp
-- ^/usr/bin/rpm.*
-- ^/var/lib/rpm
-
-# Build deps that got thrown-in by zypper
-# XXX: To keep until https://github.com/mudler/luet/issues/173 is delivered,
-# or we either create another luet repository for runtime deps
-- ^/usr/share/bison
-- ^/usr/share/automake
-- ^/usr/share/autoconf
-- ^/usr/share/aclocal
-- ^/usr/share/texinfo
-- ^/usr/share/libtool
-
-- texinfo.mo
-- git.mo
-- flex.mo
-- ^/usr/libexec/git
-- ^/usr/lib64/pkgconfig
-- ^/usr/lib64/ldscripts
-- ^/usr/lib64/gcc
-- ^/usr/bin/git.*
-- ^/usr/bin/gcc.*
-- ^/usr/bin/flex.*
-- ^/usr/bin/autom.*
-- ^/usr/bin/autoconf.*
-- ^/usr/bin/bison.*
-- ^/usr/bin/libtool.*
-- ^/usr/x86_64-suse-linux
-- ^/usr/lib64/rpm-plugins
-# Yast
-- ^/var/lib/YaST2
-
-# General
-- ^/usr/include
-#- ^/usr/local
-- ^/usr/local/bin
-- ^/usr/local/go
-- ^/usr/local/include
-- ^/usr/local/lib.*
-- ^/usr/local/man
-- ^/usr/local/sbin
-- ^/usr/local/share
-- ^/usr/local/src
-- ^/usr/local/games
-
-# Some golang package leftovers
-- ^/root/.cache

--- a/packages/sampleOS/definition.yaml
+++ b/packages/sampleOS/definition.yaml
@@ -1,4 +1,4 @@
 name: "sampleOS"
 category: "system"
-version: "0.4.4"
+version: "0.5.0"
 brand_name: "sampleOS"

--- a/packages/sampleOS/setup.yaml
+++ b/packages/sampleOS/setup.yaml
@@ -20,49 +20,63 @@ stages:
         NAME: "cOS"
         ID: "cOS"
         ANSI_COLOR: "0;32"
-        BUG_REPORT_URL: "https://github.com/mudler/cOS/issues"
-        HOME_URL: "https://github.com/mudler/cOS"
-        DOCUMENTATION_URL: "https://github.com/mudler/cOS"
+        BUG_REPORT_URL: "https://github.com/rancher-sandbox/cos-toolkit-sample-repo/issues"
+        HOME_URL: "https://github.com/rancher-sandbox/cos-toolkit-sample-repo"
+        DOCUMENTATION_URL: "https://github.com/rancher-sandbox/cos-toolkit-sample-repo"
         VERSION: ":VERSION:"
         PRETTY_NAME: ":PRETTY_NAME:"
     - name: "Grub"
       files:
-      - path: /boot/grub2/grub.cfg
+      - path: /etc/cos/grub.cfg
         content: |
-            set timeout=10
-            set default="${saved_entry}"
+              set timeout=10
+              set default="${saved_entry}"
 
-            set fallback="0 1 2"
-            set gfxmode=auto
-            set gfxpayload=keep
-            insmod all_video
-            insmod gfxterm
-            menuentry "cOS" --id cos {
-              search.fs_label COS_STATE root
-              set img=/cOS/active.img
-              loopback loop0 /$img
-              set root=($root)
-              linux (loop0)/boot/vmlinuz console=tty1 ro root=LABEL=COS_ACTIVE iso-scan/filename=/cOS/active.img panic=5
-              initrd (loop0)/boot/initrd
-            }
+              set fallback="0 1 2"
+              set gfxmode=auto
+              set gfxpayload=keep
+              insmod all_video
+              insmod gfxterm
+              menuentry "sampleOS" --id cos {
+                search.fs_label COS_STATE root
+                set img=/cOS/active.img
+                set label=COS_ACTIVE
+                loopback loop0 /$img
+                set root=($root)
+                source (loop0)/etc/cos/bootargs.cfg
+                linux (loop0)$kernel $kernelcmd
+                initrd (loop0)$initramfs
+              }
 
-            menuentry "cOS (fallback)" --id fallback {
-              search.fs_label COS_STATE root
-              set img=/cOS/passive.img
-              loopback loop0 /$img
-              set root=($root)
-              linux (loop0)/boot/vmlinuz console=tty1 ro root=LABEL=COS_PASSIVE iso-scan/filename=/cOS/passive.img panic=5
-              initrd (loop0)/boot/initrd
-            }
+              menuentry "sampleOS (fallback)" --id fallback {
+                search.fs_label COS_STATE root
+                set img=/cOS/passive.img
+                set label=COS_PASSIVE
+                loopback loop0 /$img
+                set root=($root)
+                source (loop0)/etc/cos/bootargs.cfg
+                linux (loop0)$kernel $kernelcmd
+                initrd (loop0)$initramfs
+              }
 
-            menuentry "cOS recovery" --id recovery {
-              search.fs_label COS_RECOVERY root
-              set img=/cOS/recovery.img
-              loopback loop0 /$img
-              set root=($root)
-              linux (loop0)/boot/vmlinuz console=tty1 ro root=LABEL=COS_SYSTEM iso-scan/filename=/cOS/recovery.img panic=5
-              initrd (loop0)/boot/initrd
-            }
+              menuentry "sampleOS recovery" --id recovery {
+                search.fs_label COS_RECOVERY root
+                set img=/cOS/recovery.img
+                set label=COS_SYSTEM
+                loopback loop0 /$img
+                set root=($root)
+                source (loop0)/etc/cos/bootargs.cfg
+                linux (loop0)$kernel $kernelcmd
+                initrd (loop0)$initramfs
+              }
+        permissions: 0600
+        owner: 0
+        group: 0
+      - path: /etc/cos/bootargs.cfg
+        content: |
+            set kernel=/boot/vmlinuz
+            set kernelcmd="console=tty1 root=LABEL=$label iso-scan/filename=$img panic=5 security=selinux selinux=1"
+            set initramfs=/boot/initrd
         permissions: 0600
         owner: 0
         group: 0

--- a/packages/sampleOSService/build.yaml
+++ b/packages/sampleOSService/build.yaml
@@ -11,5 +11,5 @@ steps:
 - zypper in -y {{.Values.additional_packages}}
 - go build -o sampleOSService main.go 
 - mv sampleOSService /usr/bin
+- mkdir -p /system/oem/
 - cp 10_sampleOSService.yaml /system/oem/
-- useradd --system dummyuser

--- a/packages/selinux-policies/build.yaml
+++ b/packages/selinux-policies/build.yaml
@@ -1,0 +1,10 @@
+requires:
+- name: "selinux-policies"
+  category: "system"
+  version: ">=0"
+
+steps:
+- sed -i "s|^SELINUX=.*|SELINUX=permissive|g" /etc/selinux/config
+- rm -rf /.autorelabel
+- checkmodule -M -m -o sampleOS.mod sampleOS.te && semodule_package -o sampleOS.pp -m sampleOS.mod
+- semodule -i sampleOS.pp

--- a/packages/selinux-policies/definition.yaml
+++ b/packages/selinux-policies/definition.yaml
@@ -1,0 +1,3 @@
+name: "policy"
+category: "selinux"
+version: 0.0.6+2

--- a/packages/selinux-policies/sampleOS.te
+++ b/packages/selinux-policies/sampleOS.te
@@ -1,0 +1,80 @@
+#==== cOS SELinux targeted policy module ========
+#
+# Disclaimer: This module is definition is for illustration use only. It
+# has no guarantees of completeness, accuracy and usefulness. It should
+# not be used "as is".
+# 
+
+
+module sampleOS 1.0;
+
+require {
+	type init_t;
+	type audisp_t;
+	type getty_t;
+	type unconfined_t;
+	type initrc_t;
+	type bin_t;
+	type tmpfs_t;
+	type wicked_t;
+	type systemd_logind_t;
+	type sshd_t;
+	type lib_t;
+	type unlabeled_t;
+	type chkpwd_t;
+	type unconfined_service_t;
+	type usr_t;
+	type local_login_t;
+	type cert_t;
+	type system_dbusd_t;
+	class lnk_file read;
+	class file { execmod getattr open read };
+	class dir { getattr read search watch };
+}
+
+#============= audisp_t ==============
+allow audisp_t tmpfs_t:lnk_file read;
+
+#============= chkpwd_t ==============
+allow chkpwd_t tmpfs_t:file { getattr open read };
+
+#============= getty_t ==============
+allow getty_t tmpfs_t:file { getattr open read };
+
+#============= init_t ==============
+allow init_t cert_t:dir watch;
+allow init_t usr_t:dir watch;
+
+#============= initrc_t ==============
+
+#!!!! This avc can be allowed using the boolean 'selinuxuser_execmod'
+allow initrc_t bin_t:file execmod;
+
+#============= local_login_t ==============
+allow local_login_t tmpfs_t:file { getattr open read };
+allow local_login_t tmpfs_t:lnk_file read;
+
+#============= sshd_t ==============
+allow sshd_t tmpfs_t:lnk_file read;
+
+#============= system_dbusd_t ==============
+allow system_dbusd_t lib_t:dir watch;
+allow system_dbusd_t tmpfs_t:lnk_file read;
+
+#============= systemd_logind_t ==============
+allow systemd_logind_t unlabeled_t:dir { getattr search };
+
+#============= unconfined_service_t ==============
+
+#!!!! This avc can be allowed using the boolean 'selinuxuser_execmod'
+allow unconfined_service_t bin_t:file execmod;
+
+#============= unconfined_t ==============
+
+#!!!! This avc can be allowed using the boolean 'selinuxuser_execmod'
+allow unconfined_t bin_t:file execmod;
+
+#============= wicked_t ==============
+allow wicked_t tmpfs_t:dir read;
+allow wicked_t tmpfs_t:file { getattr open read };
+allow wicked_t tmpfs_t:lnk_file read;


### PR DESCRIPTION
This PR needs https://github.com/rancher-sandbox/cOS-toolkit/pull/215 merged in order first to have a working `cowsay`. It fails otherwise for a perl module not capable of looking up `re` correctly which is in it.

To note, it didn't actually required a change in cOS because with a different strategy we can access to the underlying build container, I've split that in a separate branch so it can maybe stay around as an example https://github.com/rancher-sandbox/cos-toolkit-sample-repo/commit/1e9e33a7feb600ecef5948d137659f95e8e31b0b (I've also added a comment in the buildpsec about it)