### PR TITLE
Set VERIFY to false for upgrades

### DIFF
--- a/packages/sampleOS/02_upgrades.yaml
+++ b/packages/sampleOS/02_upgrades.yaml
@@ -48,3 +48,4 @@ stages:
        environment:
          UPGRADE_IMAGE: system/sampleOS
          CHANNEL_UPGRADES: "true"
+         VERIFY: "false"


### PR DESCRIPTION
As this derivative is not generating the metadata necessary to validate upgrade images, we should set the verify to disabled for now

Blocked until https://github.com/rancher-sandbox/cOS-toolkit/pull/185 is merged

Signed-off-by: Itxaka <igarcia@suse.com>